### PR TITLE
Travis: test Node.js 0.12 and io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "iojs"
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
Enable testing on Node 0.12 and io.js
